### PR TITLE
Use `path.sep` instead of hardcoded `/`.

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ exports.contains = function contains(mainPath, subPath) {
   mainPath = resolvePath(mainPath);
   subPath = resolvePath(subPath);
   return subPath.indexOf(mainPath) === 0
-    && subPath.slice(mainPath.length)[0] === '/';
+    && subPath.slice(mainPath.length)[0] === sep;
 };
 
 exports.within = function within(subPath, mainPath) {


### PR DESCRIPTION
On Windows `\` is used as directory seperator. `contains()` and `within()` will not work with the hardcoded `/` as seperator. Use `path.sep` instead.
